### PR TITLE
Add Devise authentication with basic Inertia pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,10 @@ gem 'rails', '~> 6.0.3', '>= 6.0.3.4'
 gem 'pg', '>= 0.18', '< 2.0'
 # Use Puma as the app server
 gem 'puma', '~> 4.1'
+# Authentication
+gem 'devise'
+# Inertia.js adapter
+gem 'inertia-rails'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production

--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ bundle install
 yarn install
 rails db:create db:migrate
 bin/dev
+
+Default login for development: admin@example.com / password

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,8 @@
-class ApplicationController < ActionController::API
+class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
+  include InertiaRails::Controller
+
+  before_action :authenticate_user!, unless: :devise_controller?
+
+  inertia_share flash: -> { { notice: flash[:notice], alert: flash[:alert] } }
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,11 @@
+class PagesController < ApplicationController
+  skip_before_action :authenticate_user!, only: :login
+
+  def login
+    render inertia: 'Login'
+  end
+
+  def home
+    render inertia: 'Home', props: { user: current_user.as_json(only: [:id, :email]) }
+  end
+end

--- a/app/frontend/entrypoints/application.js
+++ b/app/frontend/entrypoints/application.js
@@ -1,0 +1,23 @@
+import { createApp, h } from 'vue'
+import { createInertiaApp } from '@inertiajs/inertia-vue3'
+import DefaultLayout from '../layouts/DefaultLayout.vue'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+import '@mdi/font/css/materialdesignicons.css'
+
+createInertiaApp({
+  resolve: name => {
+    const pages = import.meta.glob('../pages/**/*.vue', { eager: true })
+    let page = pages[`../pages/${name}.vue`]
+    page.default.layout = page.default.layout || DefaultLayout
+    return page
+  },
+  setup({ el, App, props, plugin }) {
+    const vuetify = createVuetify({ components, directives })
+    createApp({ render: () => h(App, props) })
+      .use(plugin)
+      .use(vuetify)
+      .mount(el)
+  },
+})

--- a/app/frontend/layouts/DefaultLayout.vue
+++ b/app/frontend/layouts/DefaultLayout.vue
@@ -1,0 +1,10 @@
+<template>
+  <v-app>
+    <v-main>
+      <slot />
+    </v-main>
+  </v-app>
+</template>
+
+<script setup>
+</script>

--- a/app/frontend/pages/Home.vue
+++ b/app/frontend/pages/Home.vue
@@ -1,0 +1,14 @@
+<template>
+  <DefaultLayout>
+    <v-container class="pa-4">
+      <h1 class="text-h5 mb-4">Welcome {{ user.email }}</h1>
+      <p>User ID: {{ user.id }}</p>
+    </v-container>
+  </DefaultLayout>
+</template>
+
+<script setup>
+const props = defineProps({
+  user: Object
+})
+</script>

--- a/app/frontend/pages/Login.vue
+++ b/app/frontend/pages/Login.vue
@@ -1,0 +1,19 @@
+<template>
+  <DefaultLayout>
+    <v-container class="pa-4 max-w-md mx-auto">
+      <h1 class="text-h5 mb-4">Login</h1>
+      <form method="post" action="/users/sign_in">
+        <input type="hidden" name="authenticity_token" :value="csrf" />
+        <v-text-field label="Email" name="user[email]" v-model="form.email" required></v-text-field>
+        <v-text-field label="Password" type="password" name="user[password]" v-model="form.password" required></v-text-field>
+        <v-btn type="submit" class="mt-4" color="primary">Login</v-btn>
+      </form>
+    </v-container>
+  </DefaultLayout>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+const form = ref({ email: '', password: '' })
+const csrf = document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+</script>

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,4 @@
+class User < ApplicationRecord
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>FixFlow</title>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= vite_client_tag %>
+    <%= vite_javascript_tag 'application' %>
+  </head>
+  <body>
+    <%= inertia_include_tags %>
+  </body>
+</html>

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,12 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins 'example.com'
-#
-#     resource '*',
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins '*'
+
+    resource '*',
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,6 @@
+Devise.setup do |config|
+  config.secret_key = 'temporary_devise_secret' unless Rails.env.production?
+  config.mailer_sender = 'please-change-me@example.com'
+  require 'devise/orm/active_record'
+  config.navigational_formats = ['*/*', :html, :turbo_stream]
+end

--- a/config/initializers/inertia.rb
+++ b/config/initializers/inertia.rb
@@ -1,0 +1,3 @@
+InertiaRails.configure do |config|
+  config.layout = 'default'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,6 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  devise_for :users
+
+  root to: 'pages#login'
+  get '/home', to: 'pages#home'
 end

--- a/db/migrate/20240715000000_devise_create_users.rb
+++ b/db/migrate/20240715000000_devise_create_users.rb
@@ -1,0 +1,41 @@
+class DeviseCreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :users do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      # t.integer  :sign_in_count, default: 0, null: false
+      # t.datetime :current_sign_in_at
+      # t.datetime :last_sign_in_at
+      # t.string   :current_sign_in_ip
+      # t.string   :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false
+      # t.string   :unlock_token
+      # t.datetime :locked_at
+
+      t.timestamps null: false
+    end
+
+    add_index :users, :email, unique: true
+    add_index :users, :reset_password_token, unique: true
+    # add_index :users, :confirmation_token,   unique: true
+    # add_index :users, :unlock_token,         unique: true
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,9 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+
+if Rails.env.development?
+  user = User.find_or_create_by!(email: 'admin@example.com') do |u|
+    u.password = 'password'
+    u.password_confirmation = 'password'
+  end
+
+  puts "\e[1mLogin with: #{user.email} / password\e[0m"
+end

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "vue": "^3.4.0",
+    "@inertiajs/inertia": "^0.11.0",
+    "@inertiajs/inertia-vue3": "^0.7.0",
+    "vuetify": "^3.5.0"
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import RubyPlugin from 'vite-plugin-ruby'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [RubyPlugin(), vue()]
+})


### PR DESCRIPTION
## Summary
- add devise and inertia gems
- create Devise user model and migration
- handle CORS via rack-cors
- add seeds file that prints login creds in bold
- build Inertia login and home pages with layout
- wire up routes and application controller for Inertia
- add basic JS/Vue setup

## Testing
- `bundle --version` *(fails: ruby not installed)*


------
https://chatgpt.com/codex/tasks/task_e_6864cbdc89c48323ac5a79001c6fc1a1